### PR TITLE
fix: [network] upgrade the version of the VPC module

### DIFF
--- a/modules/eks-cluster/main.tf
+++ b/modules/eks-cluster/main.tf
@@ -19,7 +19,7 @@ module "network" {
   tags = local.tags
 }
 
-// The below datas ources refer to a workaround with an issue with the default KMS key without resource-based policy:
+// The below datasources refer to a workaround with an issue with the default KMS key without resource-based policy:
 // associated with it. Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2327#issuecomment-1355581682
 data "aws_iam_session_context" "current" {
   # "This data source provides information on the IAM source role of an STS assumed role. For non-role ARNs, this data source simply passes the ARN through in issuer_arn."

--- a/modules/eks-cluster/modules/network/main.tf
+++ b/modules/eks-cluster/modules/network/main.tf
@@ -3,7 +3,7 @@
 */
 module "network" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.18.1"
+  version = "5.1.2"
 
   name = local.network_params.name
 


### PR DESCRIPTION
# Description

This change upgrades the internal VPC module to v5.1.2. In addition, this change adds a workaround for KMS; details shared here https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2327#issuecomment-1355581682.