### PR TITLE
feat: update the Kubernetes API version to 1.26

### DIFF
--- a/files/helm-values/private-ingress-controller.values.yaml
+++ b/files/helm-values/private-ingress-controller.values.yaml
@@ -46,7 +46,7 @@ controller:
       cpu: 500m
       memory: 256Mi
   autoscaling:
-    enabled: "true"
+    enabled: "false"
     minReplicas: 1
     maxReplicas: 7
     targetCPUUtilizationPercentage: 71

--- a/files/helm-values/public-ingress-controller.values.yaml
+++ b/files/helm-values/public-ingress-controller.values.yaml
@@ -46,7 +46,7 @@ controller:
       cpu: 500m
       memory: 256Mi
   autoscaling:
-    enabled: "true"
+    enabled: "false"
     minReplicas: 1
     maxReplicas: 7
     targetCPUUtilizationPercentage: 71

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "vpc_nat_gateway_type" {
 
 variable "kubernetes_api_version" {
   type        = string
-  default     = "1.23"
+  default     = "1.26"
   description = <<-EOF
     Specify the version of the Kubernetes API.
   EOF


### PR DESCRIPTION
# Description

This change increases the default version of the Kubernetes API to 1.26.  Because of the nonstable autoscaling API objects in the Ingress Controller charts, this change completely disables the autoscaling for a later moment. 