### PR TITLE
fix(access-management): order of the default policy #minor

### DIFF
--- a/examples/external-network/main.tf
+++ b/examples/external-network/main.tf
@@ -12,4 +12,5 @@ module "example_with_external_network_configuration" {
   cluster_network_external_vpc_id                   = "vpc-0a1b2c3d4e5f67890"
   cluster_network_external_node_subnet_ids          = ["subnet-0a1b2c3d4e5f67891", "subnet-0a1b2c3d4e5f67892"]
   cluster_network_external_control_plane_subnet_ids = ["subnet-0a1b2c3d4e5f67890", "subnet-0a1b2c3d4e5f67891"]
+  cluster_autoscaler_subnet_selector                = "1"
 }

--- a/examples/internal-network-full/main.tf
+++ b/examples/internal-network-full/main.tf
@@ -2,6 +2,7 @@ module "example_full_internal_network" {
   source = "../.."
 
   prefix                                                 = "full-nw"
+  cluster_autoscaler_subnet_selector                     = "1"
   cluster_network_type                                   = "internal"
   cluster_network_internal_vpc_cidr                      = "10.0.0.0/16"
   cluster_network_internal_vpc_nat_gateway_type          = "one_nat_gateway_per_az"

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -1,3 +1,4 @@
 module "example_no_user_input" {
-  source = "../.."
+  source                             = "../.."
+  cluster_autoscaler_subnet_selector = "1"
 }

--- a/examples/provide-cluster-scope-access-through-iam-role/main.tf
+++ b/examples/provide-cluster-scope-access-through-iam-role/main.tf
@@ -1,6 +1,6 @@
 module "cluster_scoped_access_entry_through_iam" {
-  source = "../.."
-
+  source                             = "../.."
+  cluster_autoscaler_subnet_selector = "1"
   cluster_access_management = {
     list = {
       admins = {
@@ -9,7 +9,8 @@ module "cluster_scoped_access_entry_through_iam" {
           admins = {
             policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
             access_scope = {
-              type = "cluster"
+              type       = "cluster"
+              namespaces = []
             }
           }
         }

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ module "kubernetes" {
   cluster_tags                               = try(coalesce(var.cluster_tags, {}), {})
   create_cluster_primary_security_group_tags = try(coalesce(var.cluster_security_group.create_primary_security_group_tags, true), true)
   cluster_timeouts                           = try(coalesce(var.cluster_timeouts, {}), {})
-  access_entries = try(merge(coalesce(var.cluster_access_management.list, {}), {
+  access_entries = try(coalesce(var.cluster_access_management.list, {
     # The below code block is a default access management configuration that relies fully on the new API for access entries and access policies.
     # It is necessary for deploying Kubernetes resources with the Kubernetes and Helm provider.
     aws_account_admins = {
@@ -82,7 +82,7 @@ module "kubernetes" {
         }
       }
     }
-  }), {})
+  }))
   enable_cluster_creator_admin_permissions     = try(coalesce(var.cluster_access_management.enable_cluster_creator_admin_permissions, false), false)
   create_kms_key                               = try(coalesce(var.cluster_kms.enabled, true), true)
   kms_key_description                          = try(coalesce(var.cluster_kms.key_description, null), null)

--- a/variables.tf
+++ b/variables.tf
@@ -826,7 +826,7 @@ variable "cluster_access_management" {
   description = "The access management configuration for the Kubernetes cluster"
   default = {
     enable_cluster_creator_admin_permissions = false
-    list                                     = {}
+    list                                     = null
   }
 }
 


### PR DESCRIPTION
## Description

This PR fixes a bug related to Kubernetes API access management via Terraform.
The previous policy always set the current caller to AWS API as one of the admins of the Kubernetes cluster. 
Now there is an order between the policies that are configured by the user and what this module tries to apply independently.

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?

The examples were executed one by one.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.