### PR TITLE
fix: update amiFamily from AL2 to AL2023 in default EC2NodeClass

### DIFF
--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -80,7 +80,7 @@ kind: EC2NodeClass
 metadata:
   name: default
 spec:
-    amiFamily: AL2
+    amiFamily: AL2023
     role: "${module.kubernetes.eks_managed_node_groups["main"].iam_role_name}"
     subnetSelectorTerms:
         - tags:


### PR DESCRIPTION
## Problem

The default EC2NodeClass in the Karpenter autoscaler configuration uses `amiFamily: AL2` (Amazon Linux 2), which is the older AMI family. Amazon Linux 2023 (AL2023) provides updated packages, improved security, and better long-term support for EKS workloads.

## Solution

Update the `amiFamily` parameter in the default EC2NodeClass from `AL2` to `AL2023` in the Karpenter configuration. This change affects the `kubectl_manifest.default_ec2_node_class` resource in `autoscaler.tf`.

**Changes:**
- `autoscaler.tf`: amiFamily updated from AL2 to AL2023 in the default EC2NodeClass spec

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] Terraform plan/apply validation
- [ ] Verified Karpenter provisioned nodes use AL2023 AMI
- [ ] Confirmed EKS cluster compatibility with AL2023

## Checklist:

- [ ] My code follows the [contribution guidelines](CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings.
- [ ] I have updated the `Chart.yaml` with a new version number, following [Semantic Versioning](https://semver.org/).
- [ ] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes.
- [ ] I have tested my changes on a live Kubernetes cluster.

## Additional Information

AL2023 is the recommended AMI family for new EKS node provisioning. Existing clusters may need to consider node drain/replace strategies if migrating from AL2-based nodes.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.