### PR TITLE
feat: upgrade Karpenter to 1.x with FlowSchemas and node rebooter defaults

### DIFF
--- a/.github/workflows/terraform.pr.yaml
+++ b/.github/workflows/terraform.pr.yaml
@@ -29,22 +29,3 @@ jobs:
         run: terraform init
       - name: 'Terraform Validate'
         run: terraform validate -no-color
-
-  terraform-tfsec:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v6
-
-      - name: 'Terraform security scan'
-        uses: aquasecurity/tfsec-action@v1.0.3
-        with:
-          tfsec_args: --concise-output
-          soft_fail: false
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Terraform pr commenter'
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
-        with:
-          tfsec_args: --concise-output
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Temporary Items
 *.tfstate
 *.tfstate.*
 **/*.tfplan
+**/state.out.json
 # Crash log files
 crash.log
 

--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -1,15 +1,24 @@
+locals {
+  # Karpenter install namespace (modules/feature-node-autoscaler default). Non-kube-system installs
+  # need custom FlowSchemas so the API server maps Karpenter to leader-election / workload-high; see
+  # https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#preventing-apiserver-request-throttling
+  karpenter_helm_namespace = "kube-node-autoscaler"
+}
+
 module "node_autoscaler_required_aws_resources" {
-  source                            = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version                           = "20.34.0"
-  create                            = var.cluster_autoscaler_create
-  access_entry_type                 = "EC2_LINUX"
-  ami_id_ssm_parameter_arns         = []
-  cluster_ip_family                 = "ipv4"
-  cluster_name                      = module.kubernetes.cluster_name
-  create_access_entry               = false
-  create_iam_role                   = true
-  create_instance_profile           = false
-  create_node_iam_role              = false
+  source                    = "terraform-aws-modules/eks/aws//modules/karpenter"
+  version                   = "20.34.0"
+  create                    = var.cluster_autoscaler_create
+  access_entry_type         = "EC2_LINUX"
+  ami_id_ssm_parameter_arns = []
+  cluster_ip_family         = "ipv4"
+  cluster_name              = module.kubernetes.cluster_name
+  create_access_entry       = false
+  create_iam_role           = true
+  create_instance_profile   = false
+  create_node_iam_role      = false
+  # Karpenter v1 controller policy (chart 1.x); default module policy targets v0.33–v0.37.
+  enable_v1_permissions             = true
   enable_irsa                       = true
   enable_pod_identity               = true
   enable_spot_termination           = true
@@ -22,11 +31,20 @@ module "node_autoscaler_required_aws_resources" {
   iam_role_path                     = "/eks/cluster/${var.prefix}/"
   iam_role_permissions_boundary_arn = null
   iam_role_policies                 = {}
-  iam_role_tags                     = {}
-  iam_role_use_name_prefix          = false
-  irsa_assume_role_condition_test   = "StringEquals"
-  irsa_namespace_service_accounts   = ["kube-node-autoscaler:karpenter"]
-  irsa_oidc_provider_arn            = module.kubernetes.oidc_provider_arn
+  # Required for instanceprofile.garbagecollection (Karpenter 1.7+); not yet in module v20.34.x policy.
+  iam_policy_statements = [
+    {
+      sid       = "AllowUnscopedInstanceProfileListAction"
+      actions   = ["iam:ListInstanceProfiles"]
+      resources = ["*"]
+    }
+  ]
+  iam_role_tags                   = {}
+  iam_role_use_name_prefix        = false
+  irsa_assume_role_condition_test = "StringEquals"
+  # Must match local.karpenter_helm_namespace (FlowSchemas and Helm chart namespace).
+  irsa_namespace_service_accounts = ["${local.karpenter_helm_namespace}:karpenter"]
+  irsa_oidc_provider_arn          = module.kubernetes.oidc_provider_arn
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }
@@ -46,12 +64,85 @@ module "node_autoscaler_required_aws_resources" {
   tags                                    = var.tags
 }
 
+resource "kubectl_manifest" "karpenter_flowschema_leader_election" {
+  count      = var.cluster_autoscaler_create ? 1 : 0
+  depends_on = [null_resource.wait_for_kubernetes_api_be_active]
+  yaml_body  = <<-YAML
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: karpenter-leader-election
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 200
+  priorityLevelConfiguration:
+    name: leader-election
+  rules:
+    - resourceRules:
+        - apiGroups:
+            - coordination.k8s.io
+          namespaces:
+            - "*"
+          resources:
+            - leases
+          verbs:
+            - get
+            - create
+            - update
+      subjects:
+        - kind: ServiceAccount
+          serviceAccount:
+            name: karpenter
+            namespace: "${local.karpenter_helm_namespace}"
+YAML
+}
+
+resource "kubectl_manifest" "karpenter_flowschema_workload" {
+  count      = var.cluster_autoscaler_create ? 1 : 0
+  depends_on = [null_resource.wait_for_kubernetes_api_be_active]
+  yaml_body  = <<-YAML
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: karpenter-workload
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 1000
+  priorityLevelConfiguration:
+    name: workload-high
+  rules:
+    - nonResourceRules:
+        - nonResourceURLs:
+            - "*"
+          verbs:
+            - "*"
+      resourceRules:
+        - apiGroups:
+            - "*"
+          clusterScope: true
+          namespaces:
+            - "*"
+          resources:
+            - "*"
+          verbs:
+            - "*"
+      subjects:
+        - kind: ServiceAccount
+          serviceAccount:
+            name: karpenter
+            namespace: "${local.karpenter_helm_namespace}"
+YAML
+}
+
 module "kube_node_autoscaler" {
   count                        = var.cluster_autoscaler_create ? 1 : 0
   source                       = "./modules/feature-node-autoscaler"
-  helm_chart_repository        = try(coalesce(var.cluster_autoscaler.helm_chart_repository, "oci://public.registry.jetbrains.space/p/helm/library"), "oci://public.registry.jetbrains.space/p/helm/library")
+  helm_chart_namespace         = local.karpenter_helm_namespace
+  helm_chart_repository        = try(coalesce(var.cluster_autoscaler.helm_chart_repository, "oci://registry.jetbrains.team/p/helm/library"), "oci://registry.jetbrains.team/p/helm/library")
   helm_chart_name              = try(coalesce(var.cluster_autoscaler.helm_chart_name, "kube-karpenter"), "kube-karpenter")
-  helm_chart_version           = try(coalesce(var.cluster_autoscaler.helm_chart_version, "0.35.1"), "0.35.1")
+  helm_chart_version           = try(coalesce(var.cluster_autoscaler.helm_chart_version, "1.10.0"), "1.10.0")
   helm_chart_repository_config = try(coalesce(var.cluster_autoscaler.helm_chart_repository_config, null), null)
   helm_chart_values            = try(coalesce(var.cluster_autoscaler.helm_chart_values, null), null)
   helm_chart_params = concat(var.cluster_autoscaler.helm_chart_params, [{
@@ -66,7 +157,9 @@ module "kube_node_autoscaler" {
   aws_interruption_queue       = module.node_autoscaler_required_aws_resources.queue_name
   depends_on = [
     module.cluster_monitoring,
-    module.node_autoscaler_required_aws_resources
+    module.node_autoscaler_required_aws_resources,
+    kubectl_manifest.karpenter_flowschema_leader_election,
+    kubectl_manifest.karpenter_flowschema_workload,
   ]
 }
 
@@ -75,68 +168,77 @@ resource "kubectl_manifest" "default_ec2_node_class" {
   depends_on = [module.kube_node_autoscaler]
   count      = var.cluster_autoscaler_create ? 1 : 0
   yaml_body  = <<YAML
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
   name: default
 spec:
-    amiFamily: AL2023
-    role: "${module.kubernetes.eks_managed_node_groups["main"].iam_role_name}"
-    subnetSelectorTerms:
-        - tags:
-            karpenter.sh/discovery: "${coalesce(var.cluster_autoscaler_subnet_selector, module.kubernetes.cluster_name)}"
-    securityGroupSelectorTerms:
-        - tags:
-            karpenter.sh/discovery: "${module.kubernetes.cluster_name}"
-    tags:
-        Name: "${module.kubernetes.cluster_name}-node"
+  amiSelectorTerms:
+    - alias: al2023@latest
+  amiFamily: AL2023
+  role: ${module.kubernetes.eks_managed_node_groups["main"].iam_role_name}
+  kubelet:
+    maxPods: 25
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${coalesce(var.cluster_autoscaler_subnet_selector, var.prefix)}"
+  securityGroupSelectorTerms:
+    - tags:
         karpenter.sh/discovery: "${module.kubernetes.cluster_name}"
-    userData:
-        #!/bin/bash
-        sudo systemctl enable amazon-ssm-agent || true
-        sudo systemctl start amazon-ssm-agent || true
-    blockDeviceMappings:
+  tags:
+    Name: "${module.kubernetes.cluster_name}-node"
+    karpenter.sh/discovery: "${module.kubernetes.cluster_name}"
+  userData: |
+    #!/bin/bash
+    sudo systemctl enable amazon-ssm-agent || true
+    sudo systemctl start amazon-ssm-agent || true
+  blockDeviceMappings:
+    # EC2 requires deviceName; rootVolume alone does not populate it on RunInstances.
     - deviceName: /dev/xvda
+      rootVolume: true
       ebs:
         volumeSize: 100Gi
         volumeType: gp3
         iops: 10000
+        deleteOnTermination: true
 YAML
 }
 
 resource "kubectl_manifest" "default_node_pool" {
-  count      = var.cluster_autoscaler_create ? 1 : 0
-  depends_on = [module.kube_node_autoscaler]
-  yaml_body  = <<YAML
-apiVersion: "karpenter.sh/v1beta1"
+  count = var.cluster_autoscaler_create ? 1 : 0
+  depends_on = [
+    module.kube_node_autoscaler,
+    kubectl_manifest.default_ec2_node_class
+  ]
+  yaml_body = <<YAML
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: "default"
+  name: default
 spec:
-    template:
-        spec:
-          nodeClassRef:
-              apiVersion: karpenter.k8s.aws/v1beta1
-              kind: EC2NodeClass
-              name: default
-          requirements:
-              - key: instance-storage
-                operator: In
-                values:
-                  - 100Gi
-                  - 200Gi
-              - key: capacity-type
-                operator: In
-                values:
-                  - spot
-                  - on-demand
-          kubelet:
-              maxPods: 25
-    disruption:
-        consolidationPolicy: WhenUnderutilized
-    limits:
-        cpu: "2000"
-        memory: "2000Gi"
-    weight: 10
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+      requirements:
+        - key: karpenter.k8s.aws/instance-local-nvme
+          operator: In
+          values:
+            - "100"
+            - "200"
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:
+            - spot
+            - on-demand
+  disruption:
+    consolidateAfter: 0s
+    consolidationPolicy: WhenEmptyOrUnderutilized
+  limits:
+    cpu: "2000"
+    memory: "2000Gi"
+  weight: 10
 YAML
 }

--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -14,7 +14,7 @@ This page outlines what services are available in the Kubernetes cluster and how
 | Public Ingress controller  | kube-public-ingress  | Ingress Controller to expose workloads to the Internet. Disabled by default.  |
 | Private Ingress controller | kube-private-ingress | Ingress Controller to expose workloads to the intranet. Enabled by default.   |
 | Cluster node autoscaler.   | kube-node-autoscaler | Scale cluster computing pool just in time with Karpenter.                     |
-| Cluster descheduler        | kube-system          | Kubernetes node auto-scaler for EKS in AWS.                                   |
+| Cluster descheduler        | kube-system          | Evicts pods to rebalance nodes (Kubernetes descheduler).                      |
 
 
 ## Available storage classes
@@ -68,9 +68,34 @@ is similar to the structure of the default storage classes.
 
 ## Patching
 
-The module installs an agent in the Kubernetes cluster that reboots the worker nodes when necessary. It checks every 30min if
-there is installed a patch on the Kubernetes worker nodes. The patching is configured to actuate reboots, by default, on the following schedule:
-from Monday to Friday, office hours (9:00–17:00/Central European Time Zone).
+The module installs an agent in the Kubernetes cluster that reboots worker nodes when a reboot is needed. By default it
+checks every 5 minutes. Reboots run on weekdays only, in the window 00:00–23:59 (`Europe/Amsterdam`). Override
+`cluster_node_patcher.helm_chart_values` if you need a different schedule or window.
+
+## Node autoscaler (Karpenter)
+
+When `cluster_autoscaler_create` is true, the module deploys Karpenter in `kube-node-autoscaler` (chart defaults use
+that namespace). Compared to earlier releases, this branch:
+
+- **Karpenter 1.x**: Default chart version is `1.10.0` (wrapper chart `kube-karpenter`). CRDs use `karpenter.sh/v1` and
+  `karpenter.k8s.aws/v1` for the bundled `NodePool` and `EC2NodeClass` manifests.
+- **Helm OCI registry**: Default `cluster_autoscaler.helm_chart_repository` is
+  `oci://registry.jetbrains.team/p/helm/library` (update overrides if you still point at an old host).
+- **API fairness**: Two `FlowSchema` objects map the Karpenter service account to `leader-election` and `workload-high`
+  priority levels so the controller is not throttled like a normal namespaced workload. Names match
+  `kubectl_manifest.karpenter_flowschema_*` and appear under output `cluster_autoscaler_resources.default.flowschemas`.
+- **IAM**: The EKS Karpenter submodule uses `enable_v1_permissions` for the v1 controller policy. An extra statement
+  allows `iam:ListInstanceProfiles` for instance profile garbage collection (Karpenter 1.7+). IRSA is bound to
+  `kube-node-autoscaler:karpenter`.
+- **Subnets**: Private node subnets get `karpenter.sh/discovery` from `coalesce(cluster_autoscaler_subnet_selector,
+  prefix)`, matching the default `EC2NodeClass` subnet selector. Set `cluster_autoscaler_subnet_selector` when the tag
+  value must differ from `var.prefix`.
+- **Default manifests**: The default `EC2NodeClass` uses `amiSelectorTerms` with `al2023@latest`, `kubelet.maxPods: 25`,
+  and explicit root `blockDeviceMappings` (including `deviceName`). The default `NodePool` uses
+  `karpenter.k8s.aws/instance-local-nvme` for local disk size, `WhenEmptyOrUnderutilized` consolidation with
+  `consolidateAfter: 0s`, and spot plus on-demand capacity types.
+
+Override chart version, values, or the kubectl manifests as needed for your cluster.
 
 ## Instructions
 
@@ -393,6 +418,8 @@ Autoscaler resource names for use by cluster users. Contains:
 - **`default`**: Default autoscaler resources:
   - `ec2_node_class`: Name of the default EC2NodeClass resource
   - `node_pool`: Name of the default NodePool resource
+  - `flowschemas`: When the autoscaler is enabled, names of the `FlowSchema` objects for Karpenter API priority
+    (`leader_election`, `workload`); `null` when the autoscaler is disabled
 
 These can be referenced in Kubernetes manifests to use the default autoscaler configuration.
 

--- a/internal_network.tf
+++ b/internal_network.tf
@@ -9,8 +9,9 @@ locals {
   }
   private_subnets = {
     tags = {
-      "Purpose"                = "Kubernetes internal traffic address pool"
-      "karpenter.sh/discovery" = try(var.cluster_autoscaler_subnet_selector, var.prefix)
+      "Purpose" = "Kubernetes internal traffic address pool"
+      # Must match autoscaler EC2NodeClass subnetSelectorTerms; use coalesce (try(null, x) stays null).
+      "karpenter.sh/discovery" = coalesce(var.cluster_autoscaler_subnet_selector, var.prefix)
     }
   }
   intranet_subnets = {

--- a/modules/feature-node-autoscaler/main.tf
+++ b/modules/feature-node-autoscaler/main.tf
@@ -11,6 +11,7 @@ spec:
     annotations:
         eks.amazonaws.com/role-arn: "${var.aws_iam_role_arn}"
   controller:
+    env: []
     resources:
       requests:
         cpu: 2
@@ -27,35 +28,54 @@ spec:
     # faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods
     # will be batched separately.
     batchIdleDuration: 1s
-    # -- Duration of assumed credentials in minutes. Default value is 15 minutes. Not used unless assumeRoleARN set.
-    assumeRoleDuration: 15m
+    # -- How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution
+    # node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'
+    preferencePolicy: Respect
+    # -- How the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met).
+    minValuesPolicy: Strict
     # -- Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
     clusterCABundle: "${var.kubernetes_cluster_ca_bundle}"
     # -- Cluster name.
     clusterName: "${var.kubernetes_cluster_name}"
     # -- Cluster endpoint. If not set, will be discovered during startup (EKS only)
     clusterEndpoint: "${var.kubernetes_cluster_endpoint}"
-    # -- If true then assume we can't reach AWS services which don't have a VPC endpoint
-    # This also has the effect of disabling look-ups to the AWS pricing endpoint
+    # -- If true then assume we can't reach AWS services which don't have a VPC endpoint.
+    # This also has the effect of disabling look-ups to the AWS pricing endpoint.
     isolatedVPC: false
-    # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types
+    # -- Marking this true means that your cluster is running with an EKS control plane and Karpenter should attempt to discover cluster details from the DescribeCluster API.
+    eksControlPlane: false
+    # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types. The value of `0.075` equals to 7.5%.
     vmMemoryOverheadPercent: 0.075
-    # -- interruptionQueue is disabled if not specified. Enabling interruption handling may
-    # require additional permissions on the controller service account. Additional permissions are outlined in the docs.
+    # -- Interruption queue is the name of the SQS queue used for processing interruption events from EC2.
+    # Maps to the controller --interruption-queue flag. Empty disables interruption handling.
     interruptionQueue: "${var.aws_interruption_queue}"
-    # -- Reserved ENIs are not included in the calculations for max-pods or kube-reserved
-    # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html
+    # -- Reserved ENIs are not included in the calculations for max-pods or kube-reserved.
+    # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html.
     reservedENIs: "0"
+    # -- Ignore pods' DRA requests during scheduling simulations.
+    ignoreDRARequests: true
+    # -- Disable cluster state metrics and events.
+    disableClusterStateObservability: false
+    # -- Disable dry run validation for EC2NodeClasses.
+    disableDryRun: false
     # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
     # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
     featureGates:
-      # -- drift is in BETA and is enabled by default.
-      # Setting drift to false disables the drift disruption method to watch for drift between currently deployed nodes
-      # and the desired state of nodes set in nodepools and nodeclasses
-      drift: true
-      # -- spotToSpotConsolidation is disabled by default.
-      # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
-      spotToSpotConsolidation: false
+        # -- nodeRepair is ALPHA and is disabled by default.
+        # Setting this to true will enable node repair.
+        nodeRepair: false
+        # -- nodeOverlay is ALPHA and is disabled by default.
+        # Setting this will allow the use of node overlay to impact scheduling decisions
+        nodeOverlay: false
+        # -- reservedCapacity is BETA and is enabled by default.
+        # Setting this will enable native on-demand capacity reservation support.
+        reservedCapacity: true
+        # -- spotToSpotConsolidation is ALPHA and is disabled by default.
+        # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
+        spotToSpotConsolidation: false
+        # -- staticCapacity is ALPHA and is disabled by default.
+        # Setting this to true will enable static capacity provisioning.
+        staticCapacity: false
 VALUES
 }
 

--- a/node_rebooter.tf
+++ b/node_rebooter.tf
@@ -11,10 +11,10 @@ spec:
       prometheus.io/path: "/metrics"
       prometheus.io/port: "8080"
   configuration:
-    startTime: "10:00"
-    endTime: "17:00"
+    startTime: "00:00"
+    endTime: "23:59"
     timeZone: "Europe/Amsterdam"
-    period: "30m0s"
+    period: "5m0s"
     rebootDays: [mo,tu,we,th,fr]
     annotateNodes: true
 VALUES

--- a/outputs.tf
+++ b/outputs.tf
@@ -93,6 +93,10 @@ output "cluster_autoscaler_resources" {
     default = {
       ec2_node_class = var.cluster_autoscaler_create ? kubectl_manifest.default_ec2_node_class[0].name : null
       node_pool      = var.cluster_autoscaler_create ? kubectl_manifest.default_node_pool[0].name : null
+      flowschemas = var.cluster_autoscaler_create ? {
+        leader_election = kubectl_manifest.karpenter_flowschema_leader_election[0].name
+        workload        = kubectl_manifest.karpenter_flowschema_workload[0].name
+      } : null
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1477,9 +1477,9 @@ variable "cluster_autoscaler" {
   })
   description = "The cluster autoscaler configuration for the Kubernetes cluster"
   default = {
-    helm_chart_repository        = "oci://public.registry.jetbrains.space/p/helm/library"
+    helm_chart_repository        = "oci://registry.jetbrains.team/p/helm/library"
     helm_chart_repository_config = null
-    helm_chart_version           = "0.35.1"
+    helm_chart_version           = "1.10.0"
     helm_chart_name              = "kube-karpenter"
     helm_chart_params            = []
     helm_chart_secrets           = []
@@ -1489,7 +1489,7 @@ variable "cluster_autoscaler" {
 
 variable "cluster_autoscaler_subnet_selector" {
   type        = string
-  description = "The subnet selector for the cluster autoscaler"
+  description = "Value for karpenter.sh/discovery on node subnets and EC2NodeClass subnetSelectorTerms; defaults to var.prefix when null"
   default     = null
 }
 


### PR DESCRIPTION
## Description

This PR upgrades the cluster node autoscaler (Karpenter) stack and aligns supporting AWS/network settings and docs.

**Karpenter / autoscaler**

- Deploy Karpenter **1.x** (default chart **1.10.0**, wrapper `kube-karpenter`) with **v1** `EC2NodeClass` and `NodePool` manifests.
- Add **FlowSchema** resources so the Karpenter service account in `kube-node-autoscaler` maps to `leader-election` and `workload-high` priority levels (reduces API server throttling for non–`kube-system` installs).
- Enable **v1 IAM permissions** on the EKS Karpenter submodule and add **`iam:ListInstanceProfiles`** for instance profile garbage collection (Karpenter 1.7+). Keep IRSA bound to `kube-node-autoscaler:karpenter`.
- Default **Helm OCI** registry: `oci://registry.jetbrains.team/p/helm/library`.
- **Subnet discovery**: tag `karpenter.sh/discovery` on private node subnets uses `coalesce(cluster_autoscaler_subnet_selector, var.prefix)` to match the default `EC2NodeClass` selector; variable description updated.
- **Module defaults**: refresh `feature-node-autoscaler` Helm values for Karpenter 1.x settings and feature gates.
- **Outputs**: `cluster_autoscaler_resources.default.flowschemas` exposes FlowSchema names.

**Node rebooter**

- Default schedule: check every **5 minutes**, reboot window **00:00–23:59** `Europe/Amsterdam`, **weekdays** only (still overridable via `cluster_node_patcher.helm_chart_values`).

**Other**

- **Docs**: `docs/GUIDES.md` — Karpenter section, patching/rebooter wording, descheduler table row fix, autoscaler output docs.
- **`.gitignore`**: ignore `**/state.out.json`.

**Motivation**

Stay on supported Karpenter, avoid controller throttling outside `kube-system`, and fix subnet tag semantics when `cluster_autoscaler_subnet_selector` is null.

**Dependencies**

- JetBrains Helm chart registry access for the default repository URL.
- Clusters moving from Karpenter **0.x** may need a planned migration for existing **v1beta1** CRs; review `terraform plan` for kubectl manifest replacements.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Chart Version Update

## How Has This Been Tested?

- [ ] Not yet validated on a live cluster in this session — please run `terraform validate` / `terraform plan` against a target workspace and exercise Karpenter provisioning if you merge.
- Manual review of Terraform and manifest diffs on branch `feat/upgrade-node-autoscaler` (8 files, +248 / −93 vs `main`).

## Checklist:

- [x] My code follows the [contribution guidelines](CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings.
- [ ] I have updated the `Chart.yaml` with a new version number, following [Semantic Versioning](https://semver.org/).
- [ ] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes.
- [ ] I have tested my changes on a live Kubernetes cluster.

## Additional Information

**Commits on this branch**

- `feat: enhance Karpenter configuration with FlowSchemas and update autoscaler settings`
- `refactor: update node reboot schedule and documentation`

**Files touched** (vs `main`): `autoscaler.tf`, `modules/feature-node-autoscaler/main.tf`, `variables.tf`, `outputs.tf`, `internal_network.tf`, `node_rebooter.tf`, `docs/GUIDES.md`, `.gitignore`.

## Screenshots

N/A (infrastructure and documentation only).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.