### PR TITLE
 fix: QD-14326 update wrong public access CIDR field name and add additional check for NodePool

### DIFF
--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -13,10 +13,10 @@ module "node_autoscaler_required_aws_resources" {
   ami_id_ssm_parameter_arns = []
   cluster_ip_family         = "ipv4"
   cluster_name              = module.kubernetes.cluster_name
-  create_access_entry       = false
+  create_access_entry       = true
   create_iam_role           = true
   create_instance_profile   = false
-  create_node_iam_role      = false
+  create_node_iam_role      = true
   # Karpenter v1 controller policy (chart 1.x); default module policy targets v0.33–v0.37.
   enable_v1_permissions             = true
   enable_irsa                       = true
@@ -48,9 +48,9 @@ module "node_autoscaler_required_aws_resources" {
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }
-  node_iam_role_arn                       = module.kubernetes.eks_managed_node_groups["main"].iam_role_arn
   node_iam_role_attach_cni_policy         = true
-  node_iam_role_description               = null
+  node_iam_role_description               = "Karpenter node IAM role for ${var.prefix} Kubernetes cluster"
+  node_iam_role_name                      = "EKS${upper(var.prefix)}KarpenterNode"
   node_iam_role_max_session_duration      = null
   node_iam_role_path                      = "/eks/cluster/${var.prefix}/"
   node_iam_role_permissions_boundary      = null
@@ -176,7 +176,7 @@ spec:
   amiSelectorTerms:
     - alias: al2023@latest
   amiFamily: AL2023
-  role: ${module.kubernetes.eks_managed_node_groups["main"].iam_role_name}
+  role: ${module.node_autoscaler_required_aws_resources.node_iam_role_name}
   kubelet:
     maxPods: 25
   subnetSelectorTerms:
@@ -233,6 +233,15 @@ spec:
           values:
             - spot
             - on-demand
+        - key: kubernetes.io/os
+          operator: In
+          values:
+            - linux
+        - key: eks.amazonaws.com/capacityType
+          operator: In
+          values:
+            - SPOT
+            - ON_DEMAND
   disruption:
     consolidateAfter: 0s
     consolidationPolicy: WhenEmptyOrUnderutilized

--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -13,10 +13,10 @@ module "node_autoscaler_required_aws_resources" {
   ami_id_ssm_parameter_arns = []
   cluster_ip_family         = "ipv4"
   cluster_name              = module.kubernetes.cluster_name
-  create_access_entry       = true
+  create_access_entry       = false
   create_iam_role           = true
   create_instance_profile   = false
-  create_node_iam_role      = true
+  create_node_iam_role      = false
   # Karpenter v1 controller policy (chart 1.x); default module policy targets v0.33–v0.37.
   enable_v1_permissions             = true
   enable_irsa                       = true
@@ -48,9 +48,9 @@ module "node_autoscaler_required_aws_resources" {
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }
+  node_iam_role_arn                       = module.kubernetes.eks_managed_node_groups["main"].iam_role_arn
   node_iam_role_attach_cni_policy         = true
-  node_iam_role_description               = "Karpenter node IAM role for ${var.prefix} Kubernetes cluster"
-  node_iam_role_name                      = "EKS${upper(var.prefix)}KarpenterNode"
+  node_iam_role_description               = null
   node_iam_role_max_session_duration      = null
   node_iam_role_path                      = "/eks/cluster/${var.prefix}/"
   node_iam_role_permissions_boundary      = null
@@ -176,7 +176,7 @@ spec:
   amiSelectorTerms:
     - alias: al2023@latest
   amiFamily: AL2023
-  role: ${module.node_autoscaler_required_aws_resources.node_iam_role_name}
+  role: ${module.kubernetes.eks_managed_node_groups["main"].iam_role_name}
   kubelet:
     maxPods: 25
   subnetSelectorTerms:

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ module "kubernetes" {
   subnet_ids                            = try(coalesce(var.cluster_network_external_node_subnet_ids, null), module.internal_network.private_subnets, [])
   cluster_endpoint_private_access       = try(coalesce(var.cluster_vpc_config.expose_api_access_on_intranet, true), true)
   cluster_endpoint_public_access        = try(coalesce(var.cluster_vpc_config.expose_api_access_on_internet, true), true)
-  cluster_endpoint_public_access_cidrs  = try(coalesce(var.cluster_vpc_config.accept_api_requests_from_cidr_blocks, ["0.0.0.0/0"]), ["0.0.0.0/0"])
+  cluster_endpoint_public_access_cidrs  = try(coalesce(var.cluster_vpc_config.endpoint_public_access_allow_from_cidrs, ["0.0.0.0/0"]), ["0.0.0.0/0"])
   cluster_ip_family                     = try(coalesce(var.cluster_service_network_config.ip_family, "ipv4"), "ipv4")
   cluster_service_ipv4_cidr             = try(coalesce(var.cluster_service_network_config.service_ipv4_cidr, null), null)
   cluster_service_ipv6_cidr             = try(coalesce(var.cluster_service_network_config.service_ipv6_cidr, null), null)

--- a/variables.tf
+++ b/variables.tf
@@ -963,6 +963,10 @@ variable "cluster_compute_pool_aws_managed" {
     groups   = any
   })
   description = "The AWS managed compute pool configuration for the Kubernetes cluster"
+  validation {
+    condition     = contains(keys(var.cluster_compute_pool_aws_managed.groups), "main")
+    error_message = "cluster_compute_pool_aws_managed.groups must contain a \"main\" key. autoscaler.tf hardcodes eks_managed_node_groups[\"main\"] as the source of the Karpenter node IAM role."
+  }
   default = {
     defaults = {}
     groups = {


### PR DESCRIPTION
 ## Description

   This PR fixes two bugs discovered during 1.37.0 version deployment of the module on a mixed-OS (Linux + Windows) EKS cluster.

   **Bug fix 1 — wrong field name for public API access CIDRs** (relates to [#64](https://github.com/JetBrains/terraform-aws-kubernetes/issues/64))

   `main.tf` reads `cluster_vpc_config.accept_api_requests_from_cidr_blocks`, which does not exist in the `cluster_vpc_config` variable schema. The correct field name is `endpoint_public_access_allow_from_cidrs`. As a result,
   `cluster_endpoint_public_access_cidrs` always defaults to `0.0.0.0/0` regardless of what is passed via `cluster_vpc_config`, effectively making the EKS public API endpoint open to the internet even when a restricted CIDR list is provided.

   **Bug fix 2 — default NodePool missing `kubernetes.io/os` and `eks.amazonaws.com/capacityType` requirements** (relates to [#67](https://github.com/JetBrains/terraform-aws-kubernetes/issues/67))

   The default Karpenter NodePool has no `kubernetes.io/os` requirement. On clusters with Windows nodes, this causes Karpenter to include Windows DaemonSets (e.g. `ebs-csi-node-windows`) in overhead calculations for all candidate Linux nodes, making no instance type satisfy the resource requirements and blocking Linux node provisioning entirely. The `eks.amazonaws.com/capacityType` requirement is added alongside to allow runner pods with `eks.amazonaws.com/capacityType: ON_DEMAND` nodeSelector to be scheduled by Karpenter. Module at the current moment doesn't support apply of custom NodePool via configuration, so it is an additional check for linux OS to verify that managed node groups can support windows worker nodes groups.

   ## Type of change

   - [x] Bug fix (non-breaking change which fixes an issue)
   - [ ] New feature (non-breaking change which adds functionality)
   - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
   - [ ] Documentation update
   - [ ] Chart Version Update

## How Has This Been Tested?

Tested in buildfarm AWS account for 1.37.0 version of module.

## Checklist:

- [x] My code follows the [contribution guidelines](CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [ ] I have updated the `Chart.yaml` with a new version number, following [Semantic Versioning](https://semver.org/).
- [ ] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes.
- [x] I have tested my changes on a live Kubernetes cluster.

## Additional Information

The `kubernetes.io/os: linux` fix is necessary regardless of whether a dedicated Windows NodePool is used. Even with a separate Windows NodePool, the default NodePool still silently fails to provision Linux nodes when Windows DaemonSets are present, because Karpenter's overhead calculation is NodePool-independent and considers all DaemonSets that could land on a candidate node.


## Screenshots

If you have added any visual changes, please add screenshots here to demonstrate them.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.